### PR TITLE
Document Import Support

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -65,5 +65,111 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Freeze Files</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>SNES Games</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.lmmenge.sios.games</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>SNES9x Freeze Files</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.lmmenge.sios.freeze</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>SNES SRAM</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.lmmenge.sios.sram</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+		</dict>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>SNES Games</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.lmmenge.sios.games</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>sfc</string>
+					<string>smc</string>
+				</array>
+				<key>public.mime-type</key>
+				<string>application/octet-stream</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>SNES9x Freeze Files</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.lmmenge.sios.freeze</string>
+			<key>public.filename-extension</key>
+			<array>
+				<string>frz</string>
+			</array>
+			<key>public.mime-type</key>
+			<string>application/octet-stream</string>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>SNES SRAM</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.lmmenge.sios.sram</string>
+			<key>public.filename-extension</key>
+			<array>
+				<string>srm</string>
+			</array>
+			<key>public.mime-type</key>
+			<string>application/octet-stream</string>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Added support for importing SMC, SFC, FRZ, and SRM files.  I did not implement the App Delegate handlers for file import because the existing file system scanning code already does the migration from the import directory.
