### PR TITLE
Added iPega PG-9028.

### DIFF
--- a/iCade/LMBTControllerView.h
+++ b/iCade/LMBTControllerView.h
@@ -19,7 +19,8 @@ typedef enum _LMBTControllerType
   LMBTControllerType_iMpulse = 6,
   LMBTControllerType_8BitdoNES30 = 7,
   LMBTControllerType_IPEGAPG9025 = 8,
-  LMBTControllerType_Snakebyteidroidcon = 9
+  LMBTControllerType_Snakebyteidroidcon = 9,
+  LMBTControllerType_IPEGAPG9028 = 10
 } LMBTControllerType;
 
 @interface LMBTControllerView : iCadeReaderView {

--- a/iCade/LMBTControllerView.m
+++ b/iCade/LMBTControllerView.m
@@ -150,7 +150,12 @@ NSArray* LMBTSupportedControllers = nil;
                                     // Snakebyte idroid:con (thanks to Gohlan)
                                     @[@"Snakebyte idroid:con",
                                       [NSNumber numberWithInt:LMBTControllerType_Snakebyteidroidcon],
-                                      @"wedcxzaqlvogythrjnufimkp"]
+                                      @"wedcxzaqlvogythrjnufimkp"],
+                                    
+                                    // IPEGA PG-9025 (thanks to klattimer)
+                                    @[@"IPEGA PG-9028",
+                                      [NSNumber numberWithInt:LMBTControllerType_IPEGAPG9028],
+                                      @"wedcxzaqimkpjnufythroglv"]
                                     
                                    ] sortedArrayUsingComparator:^NSComparisonResult(id obj1, id obj2) {
                                      return [[obj1 firstObject] compare:[obj2 firstObject]];


### PR DESCRIPTION
- To use this controller you must press Home+B to initiate pairing (it has multiple modes)
- This controller in this mode will produce the same output for start as R1 and select as L1, L2 and R2 are used as start/select instead.
